### PR TITLE
fix: Append Object Modifier for "s3:GetObject"

### DIFF
--- a/modules/log_forwarder/main.tf
+++ b/modules/log_forwarder/main.tf
@@ -167,6 +167,7 @@ resource "aws_lambda_function" "this" {
   reserved_concurrent_executions = var.reserved_concurrent_executions
   kms_key_arn                    = var.kms_key_arn
 
+    
   dynamic "vpc_config" {
     for_each = var.subnet_ids != null && var.security_group_ids != null ? [true] : []
     content {

--- a/modules/log_forwarder/main.tf
+++ b/modules/log_forwarder/main.tf
@@ -167,7 +167,6 @@ resource "aws_lambda_function" "this" {
   reserved_concurrent_executions = var.reserved_concurrent_executions
   kms_key_arn                    = var.kms_key_arn
 
-
   dynamic "vpc_config" {
     for_each = var.subnet_ids != null && var.security_group_ids != null ? [true] : []
     content {

--- a/modules/log_forwarder/main.tf
+++ b/modules/log_forwarder/main.tf
@@ -167,7 +167,7 @@ resource "aws_lambda_function" "this" {
   reserved_concurrent_executions = var.reserved_concurrent_executions
   kms_key_arn                    = var.kms_key_arn
 
-    
+
   dynamic "vpc_config" {
     for_each = var.subnet_ids != null && var.security_group_ids != null ? [true] : []
     content {

--- a/modules/log_forwarder/main.tf
+++ b/modules/log_forwarder/main.tf
@@ -96,7 +96,7 @@ resource "aws_iam_policy" "this" {
     {
       vpc_check             = var.subnet_ids != null
       s3_check              = length(var.s3_log_bucket_arns) > 0
-      s3_log_bucket_arns    = jsonencode(var.s3_log_bucket_arns)
+      s3_log_bucket_arns    = jsonencode(formatlist("%s/*", var.s3_log_bucket_arns))
       datadog_s3_bucket     = "arn:aws:s3:::${local.bucket_name}"
       dd_api_key_secret_arn = var.dd_api_key_secret_arn
     }


### PR DESCRIPTION
## Description
Change the IAM Resource to apply to the objects in the bucket. (`/*` required)

## Motivation and Context
The DD Lambda will throw an access denied error as is. Adding `/*` in the IAM policy resolves this issue, as `s3:GetObject` is an object level action, and thus the lambda needs access to the objects.

## How Has This Been Tested?
Tested locally, by applying to my DD Log Forwarder setup to confirm the IAM policy appeared correctly.

## Screenshots (if appropriate):
