### PR TITLE
feat: add support for datadog tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ module "log_forwarder" {
   dd_api_key            = var.dd_api_key
   dd_api_key_secret_arn = var.dd_api_key_secret_arn
   dd_site               = var.dd_site
+  dd_tags               = var.dd_tags
 
   name                           = var.log_forwarder_name
   runtime                        = var.log_forwarder_runtime

--- a/modules/log_forwarder/main.tf
+++ b/modules/log_forwarder/main.tf
@@ -187,6 +187,7 @@ resource "aws_lambda_function" "this" {
         DD_USE_PRIVATE_LINK       = false
         DD_SITE                   = var.dd_site
         DD_S3_BUCKET_NAME         = local.bucket_name
+        DD_TAGS                   = var.dd_tags
       },
       var.environment_variables,
       local.version_tag

--- a/modules/log_forwarder/variables.tf
+++ b/modules/log_forwarder/variables.tf
@@ -29,6 +29,12 @@ variable "dd_site" {
   default     = "datadoghq.com"
 }
 
+variable "dd_tags" {
+  description = "Define your Datadog Tags list of comma separated strings. Ensure your tags are a comma separated list of strings with no trailing comma"
+  type        = string
+  default     = ""
+}
+
 # S3 Forwarder Bucket
 variable "create_bucket" {
   description = "Controls whether an S3 bucket should be created for the forwarder"

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "dd_site" {
   default     = "datadoghq.com"
 }
 
+variable "dd_tags" {
+  description = "Define your Datadog Tags list of comma separated strings. Ensure your tags are a comma separated list of strings with no trailing comma"
+  type        = string
+  default     = ""
+}
+
 variable "kms_alias" {
   description = "Alias of KMS key used to encrypt the Datadog API keys - must start with `alias/`"
   type        = string


### PR DESCRIPTION
## Description
Pass `var.dd_tags` as `DD_TAGS` environment variable to log forwarder function.

## Motivation and Context
We want to tag logs with some general tags.

## How Has This Been Tested?
We are using our fork with this feature in our environment.
