### PR TITLE
fix: upgrade s3 module to latest to support Terraform 0.15.x syntax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.48.0
+    rev: v1.49.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/modules/log_forwarder/README.md
+++ b/modules/log_forwarder/README.md
@@ -55,7 +55,7 @@ module "datadog_log_forwarder" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_this_s3_bucket"></a> [this\_s3\_bucket](#module\_this\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | v1.17.0 |
+| <a name="module_this_s3_bucket"></a> [this\_s3\_bucket](#module\_this\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | v1.25.0 |
 
 ## Resources
 

--- a/modules/log_forwarder/main.tf
+++ b/modules/log_forwarder/main.tf
@@ -24,7 +24,7 @@ data "aws_region" "current" {}
 
 module "this_s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "v1.17.0"
+  version = "v1.25.0"
 
   create_bucket = var.create && var.create_bucket
   bucket        = local.bucket_name


### PR DESCRIPTION
## Description
- upgrade s3 module to latest to support Terraform 0.15.x syntax

## Motivation and Context
Closes #5

## How Has This Been Tested?
- Validated using example module

## Screenshots (if appropriate):
