### PR TITLE
feat: add variable to allow setting customer managed key on s3 bucket encryption

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.2
+    rev: v1.62.3
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Examples codified under the [`examples`](./examples) are intended to give users 
 | <a name="input_api_vpce_subnet_ids"></a> [api\_vpce\_subnet\_ids](#input\_api\_vpce\_subnet\_ids) | IDs of subnets to associate with API endpoint | `list(string)` | `[]` | no |
 | <a name="input_api_vpce_tags"></a> [api\_vpce\_tags](#input\_api\_vpce\_tags) | A map of tags to apply to the API endpoint | `map(string)` | `{}` | no |
 | <a name="input_bucket_attach_deny_insecure_transport_policy"></a> [bucket\_attach\_deny\_insecure\_transport\_policy](#input\_bucket\_attach\_deny\_insecure\_transport\_policy) | Controls if S3 bucket should have deny non-SSL transport policy attacheds | `bool` | `true` | no |
+| <a name="input_bucket_encryption_settings"></a> [bucket\_encryption\_settings](#input\_bucket\_encryption\_settings) | S3 bucket server side encryption settings | `map(string)` | <pre>{<br>  "sse_algorithm": "AES256"<br>}</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Lambda artifact S3 bucket name | `string` | `""` | no |
 | <a name="input_create_agent_vpce"></a> [create\_agent\_vpce](#input\_create\_agent\_vpce) | Controls whether an agent endpoint should be created | `bool` | `false` | no |
 | <a name="input_create_api_vpce"></a> [create\_api\_vpce](#input\_create\_api\_vpce) | Controls whether a API endpoint should be created | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ module "log_forwarder" {
   bucket_name                                  = var.bucket_name
   bucket_prefix                                = var.log_forwarder_bucket_prefix
   bucket_attach_deny_insecure_transport_policy = var.bucket_attach_deny_insecure_transport_policy
+  bucket_encryption_settings                   = var.bucket_encryption_settings
 
   s3_zip_storage_class          = var.log_forwarder_s3_zip_storage_class
   s3_zip_server_side_encryption = var.log_forwarder_s3_zip_server_side_encryption

--- a/modules/log_forwarder/README.md
+++ b/modules/log_forwarder/README.md
@@ -80,6 +80,7 @@ module "datadog_log_forwarder" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_attach_deny_insecure_transport_policy"></a> [bucket\_attach\_deny\_insecure\_transport\_policy](#input\_bucket\_attach\_deny\_insecure\_transport\_policy) | Controls if S3 bucket should have deny non-SSL transport policy attacheds | `bool` | `false` | no |
+| <a name="input_bucket_encryption_settings"></a> [bucket\_encryption\_settings](#input\_bucket\_encryption\_settings) | S3 bucket server side encryption settings | `map(string)` | <pre>{<br>  "sse_algorithm": "AES256"<br>}</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Forwarder S3 bucket name | `string` | `""` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | S3 object key prefix to prepend to zip archive name | `string` | `""` | no |
 | <a name="input_create"></a> [create](#input\_create) | Controls whether the forwarder resources should be created | `bool` | `true` | no |

--- a/modules/log_forwarder/main.tf
+++ b/modules/log_forwarder/main.tf
@@ -43,9 +43,7 @@ module "this_s3_bucket" {
 
   server_side_encryption_configuration = {
     rule = {
-      apply_server_side_encryption_by_default = {
-        sse_algorithm = "AES256"
-      }
+      apply_server_side_encryption_by_default = var.bucket_encryption_settings
     }
   }
 

--- a/modules/log_forwarder/variables.tf
+++ b/modules/log_forwarder/variables.tf
@@ -48,6 +48,14 @@ variable "bucket_attach_deny_insecure_transport_policy" {
   default     = false
 }
 
+variable "bucket_encryption_settings" {
+  description = "S3 bucket server side encryption settings"
+  type        = map(string)
+  default = {
+    sse_algorithm = "AES256"
+  }
+}
+
 # Forwarder S3 Zip Objcet
 variable "bucket_prefix" {
   description = "S3 object key prefix to prepend to zip archive name"

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,14 @@ variable "bucket_attach_deny_insecure_transport_policy" {
   default     = true
 }
 
+variable "bucket_encryption_settings" {
+  description = "S3 bucket server side encryption settings"
+  type        = map(string)
+  default = {
+    sse_algorithm = "AES256"
+  }
+}
+
 # Log Forwarder S3 Objcet
 variable "log_forwarder_bucket_prefix" {
   description = "S3 object key prefix to prepend to zip archive name"


### PR DESCRIPTION
## Description
- add variable `bucket_encryption_settings`to allow setting customer managed key on s3 bucket encryption

## Motivation and Context

- Closes #10

## How Has This Been Tested?

- Tested with `examples/*`

## Screenshots (if appropriate):
